### PR TITLE
Fix website cloud link 404

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,7 +5,7 @@
     * [kubecm alias](/en-us/cli/kubecm_alias.md)
     * [kubecm completion](/en-us/cli/kubecm_completion.md)
     * [kubecm delete](/en-us/cli/kubecm_delete.md)
-    * [kubecm ls](/en-us/cli/kubecm_ls.md)
+    * [kubecm list](/en-us/cli/kubecm_list.md)
     * [kubecm merge](/en-us/cli/kubecm_merge.md)
     * [kubecm namespace](/en-us/cli/kubecm_namespace.md)
     * [kubecm rename](/en-us/cli/kubecm_rename.md)

--- a/docs/en-us/_sidebar.md
+++ b/docs/en-us/_sidebar.md
@@ -2,7 +2,7 @@
 * [Interactive operation](/en-us/interactive.md)
 * CLI References
     * [add](/en-us/cli/kubecm_add.md)
-      * [cloud](/en-us/cli/kubecm_add_cloud.md)
+    * [cloud](/en-us/cli/kubecm_cloud.md)
     * [create(experiment)](/en-us/cli/kubecm_create.md)
     * [alias](/en-us/cli/kubecm_alias.md)
     * [completion](/en-us/cli/kubecm_completion.md)

--- a/docs/zh-cn/_sidebar.md
+++ b/docs/zh-cn/_sidebar.md
@@ -2,7 +2,7 @@
 * [交互式操作](/zh-cn/interactive.md)
 * CLI 参考
     * [add](/zh-cn/cli/kubecm_add.md)
-      * [cloud](/zh-cn/cli/kubecm_add_cloud.md)
+    * [cloud](/zh-cn/cli/kubecm_cloud.md)
     * [create（实验性）](/zh-cn/cli/kubecm_create.md)
     * [alias](/zh-cn/cli/kubecm_alias.md)
     * [completion](/zh-cn/cli/kubecm_completion.md)


### PR DESCRIPTION
Fix website 404 link url at: https://kubecm.cloud/en-us/cli/kubecm_add_cloud