### PR TITLE
Fix: add oidc auth method

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sunny0826/kubecm/cmd"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure" // required for Azure
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"   // required for GKE
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func main() {


### PR DESCRIPTION
When auth provider with name oidc is used, kubecm will throw an error: no Auth Provider found for name "oidc". This commit fixes the issue.

![image](https://user-images.githubusercontent.com/15110242/210957121-5fe0bb6b-95cc-42a8-9d35-d836e975a932.png)
