### PR TITLE
chore: fix asset names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
 archives:
 - name_template: >-
     {{ .ProjectName }}_
-    {{ .Version }}_
+    {{- .Version }}_
     {{- title .Os }}_
     {{- if eq .Arch "amd64" }}x86_64
     {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
- https://github.com/sunny0826/kubecm/issues/720

```console
$ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.19.1
GitCommit:     6b46a1a6aa51e45bd281d55b6e5a2315ee82f643
GitTreeState:  false
BuildDate:     2023-06-29T12:55:30Z
BuiltBy:       goreleaser
GoVersion:     go1.20.5
Compiler:      gc
ModuleSum:     h1:MVAFo62jkj6/JflxruefIwfFTqNTeNtkT12Hab1o2Lk=
Platform:      darwin/arm64
```

## AS IS

```console
$ goreleaser release --clean --snapshot
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=915aa858471e5ea67fb195c0883d51b612bceae1 latest tag=v0.24.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.24.0-SNAPSHOT-915aa85
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/kubecm_windows_386/kubecm.exe
    • building                                       binary=dist/kubecm_linux_arm64/kubecm
    • building                                       binary=dist/kubecm_linux_amd64_v1/kubecm
    • building                                       binary=dist/kubecm_darwin_amd64_v1/kubecm
    • building                                       binary=dist/kubecm_linux_386/kubecm
    • building                                       binary=dist/kubecm_windows_amd64_v1/kubecm.exe
    • building                                       binary=dist/kubecm_darwin_arm64/kubecm
    • took: 1m37s
  • archives
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Windows_i386.tar.gz
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Linux_x86_64.tar.gz
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Darwin_arm64.tar.gz
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Linux_arm64.tar.gz
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Windows_x86_64.tar.gz
    • creating                                       archive=dist/kubecm_ v0.24.0-SNAPSHOT-915aa85_Linux_i386.tar.gz
    • took: 5s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 1m43s
  • thanks for using goreleaser!
```

Asset names includes a space.

```console
$ ls dist | grep kubecm
kubecm_ v0.24.0-SNAPSHOT-915aa85_Darwin_arm64.tar.gz
kubecm_ v0.24.0-SNAPSHOT-915aa85_Darwin_x86_64.tar.gz
kubecm_ v0.24.0-SNAPSHOT-915aa85_Linux_arm64.tar.gz
kubecm_ v0.24.0-SNAPSHOT-915aa85_Linux_i386.tar.gz
kubecm_ v0.24.0-SNAPSHOT-915aa85_Linux_x86_64.tar.gz
kubecm_ v0.24.0-SNAPSHOT-915aa85_Windows_i386.tar.gz
kubecm_ v0.24.0-SNAPSHOT-915aa85_Windows_x86_64.tar.gz
kubecm_darwin_amd64_v1
kubecm_darwin_arm64
kubecm_linux_386
kubecm_linux_amd64_v1
kubecm_linux_arm64
kubecm_windows_386
kubecm_windows_amd64_v1
```

## TO BE

```console
$ goreleaser release --clean --snapshot
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=915aa858471e5ea67fb195c0883d51b612bceae1 latest tag=v0.24.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.24.0-SNAPSHOT-915aa85
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/kubecm_windows_386/kubecm.exe
    • building                                       binary=dist/kubecm_darwin_amd64_v1/kubecm
    • building                                       binary=dist/kubecm_linux_386/kubecm
    • building                                       binary=dist/kubecm_linux_arm64/kubecm
    • building                                       binary=dist/kubecm_windows_amd64_v1/kubecm.exe
    • building                                       binary=dist/kubecm_darwin_arm64/kubecm
    • building                                       binary=dist/kubecm_linux_amd64_v1/kubecm
    • took: 5s
  • archives
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Windows_i386.tar.gz
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Windows_x86_64.tar.gz
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Linux_i386.tar.gz
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Linux_x86_64.tar.gz
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Linux_arm64.tar.gz
    • creating                                       archive=dist/kubecm_v0.24.0-SNAPSHOT-915aa85_Darwin_arm64.tar.gz
    • took: 5s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 11s
  • thanks for using goreleaser!
```

Asset names are good.

```console
$ ls dist | grep kubecm                
kubecm_darwin_amd64_v1
kubecm_darwin_arm64
kubecm_linux_386
kubecm_linux_amd64_v1
kubecm_linux_arm64
kubecm_v0.24.0-SNAPSHOT-915aa85_Darwin_arm64.tar.gz
kubecm_v0.24.0-SNAPSHOT-915aa85_Darwin_x86_64.tar.gz
kubecm_v0.24.0-SNAPSHOT-915aa85_Linux_arm64.tar.gz
kubecm_v0.24.0-SNAPSHOT-915aa85_Linux_i386.tar.gz
kubecm_v0.24.0-SNAPSHOT-915aa85_Linux_x86_64.tar.gz
kubecm_v0.24.0-SNAPSHOT-915aa85_Windows_i386.tar.gz
kubecm_v0.24.0-SNAPSHOT-915aa85_Windows_x86_64.tar.gz
kubecm_windows_386
kubecm_windows_amd64_v1
```