### PR TITLE
feat: Allow silencing context table print upon config write

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,9 +33,10 @@ import (
 )
 
 var (
-	cfgFile   string
-	uiSize    int
-	macNotify bool
+	cfgFile      string
+	uiSize       int
+	macNotify    bool
+	silenceTable bool
 )
 
 // Cli cmd struct
@@ -64,6 +65,7 @@ func (cli *Cli) setFlags() {
 	flags := cli.rootCmd.PersistentFlags()
 	flags.StringVar(&cfgFile, "config", *kubeconfig, "path of kubeconfig")
 	flags.IntVar(&uiSize, "ui-size", 4, "number of list items to show in menu at once")
+	flags.BoolVarP(&silenceTable, "silence-table", "s", false, "enable/disable output of context table on successful config update")
 	flags.BoolVarP(&macNotify, "mac-notify", "m", false, "enable to display Mac notification banner")
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -312,10 +312,14 @@ func WriteConfig(cover bool, file string, outConfig *clientcmdapi.Config) error 
 			return err
 		}
 		fmt.Printf("「%s」 write successful!\n", file)
-		err = PrintTable(outConfig)
-		if err != nil {
-			return err
+
+		if !silenceTable {
+			err = PrintTable(outConfig)
+			if err != nil {
+				return err
+			}
 		}
+
 	} else {
 		err := clientcmd.WriteToFile(*outConfig, "kubecm.config")
 		if err != nil {

--- a/docs/en-us/cli/kubecm.md
+++ b/docs/en-us/cli/kubecm.md
@@ -21,7 +21,7 @@ KubeConfig Manager.
 ### Options
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -h, --help            help for kubecm
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update

--- a/docs/en-us/cli/kubecm.md
+++ b/docs/en-us/cli/kubecm.md
@@ -15,15 +15,16 @@ KubeConfig Manager.
 [92m██  ██  ██    ██ ██   ██ ██      ██      ██  ██  ██ [0m
 [92m██   ██  ██████  ██████  ███████  ██████ ██      ██[0m
 [92m[0m
-[44;97m[44;97m Tips [0m[0m [96m[96mFind more information at: [3;32mkubecm.cloud (https://kubecm.cloud)[m[0m[0m
+[44;97m[44;97m Tips [0m[0m [96m[96mFind more information at: ]8;;https://kubecm.cloud[3;32mkubecm.cloud]8;;[0m[96m[0m[0m
 
 
 ### Options
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -h, --help            help for kubecm
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_add.md
+++ b/docs/en-us/cli/kubecm_add.md
@@ -39,8 +39,9 @@ cat /etc/kubernetes/admin.conf |  kubecm add -f -
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_add.md
+++ b/docs/en-us/cli/kubecm_add.md
@@ -39,7 +39,7 @@ cat /etc/kubernetes/admin.conf |  kubecm add -f -
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_alias.md
+++ b/docs/en-us/cli/kubecm_alias.md
@@ -31,7 +31,7 @@ $ kubecm alias -o bash
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_alias.md
+++ b/docs/en-us/cli/kubecm_alias.md
@@ -31,8 +31,9 @@ $ kubecm alias -o bash
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_clear.md
+++ b/docs/en-us/cli/kubecm_clear.md
@@ -14,7 +14,7 @@ kubecm clear
 
 ```
 
-# Clear lapsed context, cluster and user (default is /Users/user/.kube/config)
+# Clear lapsed context, cluster and user (default is /Users/guoxudong/.kube/config)
 kubecm clear
 # Customised clear lapsed files
 kubecm clear config.yaml test.yaml
@@ -30,7 +30,7 @@ kubecm clear config.yaml test.yaml
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_clear.md
+++ b/docs/en-us/cli/kubecm_clear.md
@@ -14,7 +14,7 @@ kubecm clear
 
 ```
 
-# Clear lapsed context, cluster and user (default is /Users/guoxudong/.kube/config)
+# Clear lapsed context, cluster and user (default is /Users/user/.kube/config)
 kubecm clear
 # Customised clear lapsed files
 kubecm clear config.yaml test.yaml
@@ -30,8 +30,9 @@ kubecm clear config.yaml test.yaml
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_cloud.md
+++ b/docs/en-us/cli/kubecm_cloud.md
@@ -18,7 +18,7 @@ Manage kubeconfig from cloud
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_cloud.md
+++ b/docs/en-us/cli/kubecm_cloud.md
@@ -18,8 +18,9 @@ Manage kubeconfig from cloud
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_cloud_add.md
+++ b/docs/en-us/cli/kubecm_cloud_add.md
@@ -60,7 +60,7 @@ kubecm cloud add --provider alibabacloud --cluster_id=xxxxxx
 
 ```
       --cluster_id string   kubernetes cluster id
-      --config string       path of kubeconfig (default "/Users/user/.kube/config")
+      --config string       path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify          enable to display Mac notification banner
       --provider string     public cloud
       --region_id string    cloud region id

--- a/docs/en-us/cli/kubecm_cloud_add.md
+++ b/docs/en-us/cli/kubecm_cloud_add.md
@@ -60,10 +60,11 @@ kubecm cloud add --provider alibabacloud --cluster_id=xxxxxx
 
 ```
       --cluster_id string   kubernetes cluster id
-      --config string       path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string       path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify          enable to display Mac notification banner
       --provider string     public cloud
       --region_id string    cloud region id
+  -s, --silence-table       enable/disable output of context table on successful config update
       --ui-size int         number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_cloud_list.md
+++ b/docs/en-us/cli/kubecm_cloud_list.md
@@ -45,10 +45,11 @@ kubecm cloud list --provider alibabacloud --cluster_id=xxxxxx
 
 ```
       --cluster_id string   kubernetes cluster id
-      --config string       path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string       path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify          enable to display Mac notification banner
       --provider string     public cloud
       --region_id string    cloud region id
+  -s, --silence-table       enable/disable output of context table on successful config update
       --ui-size int         number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_cloud_list.md
+++ b/docs/en-us/cli/kubecm_cloud_list.md
@@ -45,7 +45,7 @@ kubecm cloud list --provider alibabacloud --cluster_id=xxxxxx
 
 ```
       --cluster_id string   kubernetes cluster id
-      --config string       path of kubeconfig (default "/Users/user/.kube/config")
+      --config string       path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify          enable to display Mac notification banner
       --provider string     public cloud
       --region_id string    cloud region id

--- a/docs/en-us/cli/kubecm_completion.md
+++ b/docs/en-us/cli/kubecm_completion.md
@@ -59,8 +59,9 @@ kubecm completion [bash|zsh|fish|powershell] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_completion.md
+++ b/docs/en-us/cli/kubecm_completion.md
@@ -59,7 +59,7 @@ kubecm completion [bash|zsh|fish|powershell] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_create.md
+++ b/docs/en-us/cli/kubecm_create.md
@@ -28,8 +28,9 @@ kubecm create
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_create.md
+++ b/docs/en-us/cli/kubecm_create.md
@@ -28,7 +28,7 @@ kubecm create
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_delete.md
+++ b/docs/en-us/cli/kubecm_delete.md
@@ -32,7 +32,7 @@ kubecm delete my-context1 my-context2
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_delete.md
+++ b/docs/en-us/cli/kubecm_delete.md
@@ -32,8 +32,9 @@ kubecm delete my-context1 my-context2
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_export.md
+++ b/docs/en-us/cli/kubecm_export.md
@@ -31,7 +31,7 @@ kubecm export -f myconfig.yaml my-context1 my-context2
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_export.md
+++ b/docs/en-us/cli/kubecm_export.md
@@ -31,8 +31,9 @@ kubecm export -f myconfig.yaml my-context1 my-context2
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_list.md
+++ b/docs/en-us/cli/kubecm_list.md
@@ -33,7 +33,7 @@ kubecm ls kind k3s
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_list.md
+++ b/docs/en-us/cli/kubecm_list.md
@@ -33,8 +33,9 @@ kubecm ls kind k3s
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_merge.md
+++ b/docs/en-us/cli/kubecm_merge.md
@@ -34,8 +34,9 @@ kubecm merge -f dir --config kubecm.config
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_merge.md
+++ b/docs/en-us/cli/kubecm_merge.md
@@ -34,7 +34,7 @@ kubecm merge -f dir --config kubecm.config
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_namespace.md
+++ b/docs/en-us/cli/kubecm_namespace.md
@@ -12,6 +12,8 @@ Switch or change namespace interactively
 kubecm namespace [flags]
 ```
 
+![ns](../../static/ns.gif)
+
 ### Examples
 
 ```
@@ -34,7 +36,7 @@ kubecm ns kube-system
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_namespace.md
+++ b/docs/en-us/cli/kubecm_namespace.md
@@ -12,8 +12,6 @@ Switch or change namespace interactively
 kubecm namespace [flags]
 ```
 
-![ns](../../static/ns.gif)
-
 ### Examples
 
 ```
@@ -36,8 +34,9 @@ kubecm ns kube-system
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_rename.md
+++ b/docs/en-us/cli/kubecm_rename.md
@@ -28,7 +28,7 @@ kubecm rename
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_rename.md
+++ b/docs/en-us/cli/kubecm_rename.md
@@ -28,8 +28,9 @@ kubecm rename
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_switch.md
+++ b/docs/en-us/cli/kubecm_switch.md
@@ -12,8 +12,6 @@ Switch Kube Context interactively
 kubecm switch [flags]
 ```
 
-![switch](../../static/switch.gif)
-
 ### Examples
 
 ```
@@ -34,8 +32,9 @@ kubecm switch dev
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_switch.md
+++ b/docs/en-us/cli/kubecm_switch.md
@@ -12,6 +12,8 @@ Switch Kube Context interactively
 kubecm switch [flags]
 ```
 
+![switch](../../static/switch.gif)
+
 ### Examples
 
 ```
@@ -32,7 +34,7 @@ kubecm switch dev
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)

--- a/docs/en-us/cli/kubecm_version.md
+++ b/docs/en-us/cli/kubecm_version.md
@@ -19,8 +19,9 @@ kubecm version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
+      --config string   path of kubeconfig (default "/Users/user/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
+  -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)
 ```
 

--- a/docs/en-us/cli/kubecm_version.md
+++ b/docs/en-us/cli/kubecm_version.md
@@ -19,7 +19,7 @@ kubecm version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   path of kubeconfig (default "/Users/user/.kube/config")
+      --config string   path of kubeconfig (default "/Users/guoxudong/.kube/config")
   -m, --mac-notify      enable to display Mac notification banner
   -s, --silence-table   enable/disable output of context table on successful config update
       --ui-size int     number of list items to show in menu at once (default 4)


### PR DESCRIPTION
Not always one would want to print the whole table of all contexts after each successful write.
Especially if `kubecm switch` or `kubecm ns` are often used.
This PR adds the option to silence it.

[x] Added the flag
[x] Tested locally
[x] Ran `make doc-gen`