### PR TITLE
feat: Added an additional alias to the switch command

### DIFF
--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -23,7 +23,7 @@ func (sc *SwitchCommand) Init() {
 		Long: `
 Switch Kube Context interactively
 `,
-		Aliases: []string{"s"},
+		Aliases: []string{"s", "sw"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
 				return errors.New("no support for more than 1 parameter")


### PR DESCRIPTION
Before I realized there was an existing alias of `s` for the `kubecm switch` command, I setup a function in my shell profile to create one called `sw` (I also shorten kubecm to kc):

```shell
function kc() {
  if [[ $@ == "sw" ]]; then
      command kubecm switch
  else
      command kubecm "$@"
  fi
}
```

This PR adds `sw` as a native alias in addition to `s`. My muscle memory prevents me from using `kubecm s` instead 😆