### PR TITLE
Fix `delete` removes user even if another context is using it

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -65,8 +65,13 @@ func deleteContext(ctxs []string, config *clientcmdapi.Config) error {
 	for _, ctx := range ctxs {
 		if _, ok := config.Contexts[ctx]; ok {
 			delContext := config.Contexts[ctx]
-			delete(config.AuthInfos, delContext.AuthInfo)
-			delete(config.Clusters, delContext.Cluster)
+			isClusterNameExist, isUserNameExist := checkClusterAndUserNameExceptContextToDelete(config, config.Contexts[ctx])
+			if !isUserNameExist {
+				delete(config.AuthInfos, delContext.AuthInfo)
+			}
+			if !isClusterNameExist {
+				delete(config.Clusters, delContext.Cluster)
+			}
 			delete(config.Contexts, ctx)
 			fmt.Printf("Context Delete:「%s」\n", ctx)
 		} else {
@@ -78,6 +83,24 @@ func deleteContext(ctxs []string, config *clientcmdapi.Config) error {
 		return errors.New("nothing deleted！")
 	}
 	return nil
+}
+
+func checkClusterAndUserNameExceptContextToDelete(oldConfig *clientcmdapi.Config, contextToDelete *clientcmdapi.Context) (bool, bool) {
+	var (
+		isClusterNameExist bool
+		isUserNameExist    bool
+	)
+
+	for _, ctx := range oldConfig.Contexts {
+		if ctx.Cluster == contextToDelete.Cluster && ctx != contextToDelete {
+			isClusterNameExist = true
+		}
+		if ctx.AuthInfo == contextToDelete.AuthInfo && ctx != contextToDelete {
+			isUserNameExist = true
+		}
+	}
+
+	return isClusterNameExist, isUserNameExist
 }
 
 func selectDeleteContext(config *clientcmdapi.Config) (string, string, error) {

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -30,6 +30,30 @@ var (
 		Contexts: map[string]*clientcmdapi.Context{
 			"root-context": {AuthInfo: "black-user", Cluster: "pig-cluster", Namespace: "saw-ns"}},
 	}
+	delButKeepUserConfigBefore = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"black-user": {Token: "black-token"},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"pig-cluster": {Server: "http://pig.org:8080"},
+			"cow-cluster": {Server: "http://cow.org:8080"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"root-context":    {AuthInfo: "black-user", Cluster: "pig-cluster", Namespace: "saw-ns"},
+			"federal-context": {AuthInfo: "black-user", Cluster: "cow-cluster", Namespace: "hammer-ns"},
+		},
+	}
+	delButKeepUserConfigAfter = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"black-user": {Token: "black-token"},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"pig-cluster": {Server: "http://pig.org:8080"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"root-context": {AuthInfo: "black-user", Cluster: "pig-cluster", Namespace: "saw-ns"},
+		},
+	}
 )
 
 func Test_deleteContext(t *testing.T) {
@@ -46,6 +70,7 @@ func Test_deleteContext(t *testing.T) {
 		{"delete", args{[]string{"federal-context"}, &delMergeConfig}, false},
 		{"delete-not-exist", args{[]string{"a"}, &delMergeConfig}, true},
 		{"multiple-delete", args{[]string{"federal-context", "root-context"}, &delMergeConfig}, false},
+		{"delete-but-keep-user", args{[]string{"federal-context"}, &delButKeepUserConfigBefore}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,6 +82,8 @@ func Test_deleteContext(t *testing.T) {
 					checkConfig(&delRootConfigConflictAlfa, tt.args.config, t)
 				case "multiple-delete":
 					checkConfig(clientcmdapi.NewConfig(), tt.args.config, t)
+				case "delete-but-keep-user":
+					checkConfig(&delButKeepUserConfigAfter, tt.args.config, t)
 				}
 				if err != nil {
 					fmt.Println(err)


### PR DESCRIPTION
I added a check to make sure that we don't delete a user or a cluster that is in use by another context than the one getting deleted.

I also added a unit test that deletes a context that references a user that is referenced within another context.

- Fixes #814 