### PR TITLE
chore: remove `varcheck` check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - govet
     - ineffassign
     - typecheck
-    - varcheck
+    # - varcheck # deprecated - https://github.com/golangci/golangci-lint/issues/1841
     - stylecheck
     - tagliatelle
   disable:


### PR DESCRIPTION

## Description

```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
```

followup #847 

## Related Issue

<!--- If this PR relates to any open issues, please reference them here. For example: resolves #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [ ] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [ ] I have added/updated unit or e2e tests to cover my changes.
- [ ] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
