### PR TITLE
feat: allow select context for kubecm add and merge command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -104,7 +104,7 @@ func AddToLocal(newConfig *clientcmdapi.Config, path, newName string, cover bool
 	}
 
 	if reflect.DeepEqual(oldConfig, outConfig) {
-		fmt.Println("No context to import. Skipping write kubeconfig.")
+		fmt.Println("No context to add.")
 		return nil
 	}
 
@@ -139,7 +139,7 @@ func (kc *KubeConfigOption) handleContexts(oldConfig *clientcmdapi.Config, conte
 		}
 
 		if selectContext {
-			importContext := BoolUI(fmt.Sprintf("Do you want to import context「%s」? (If you select `False`, this context will not be merged)", newName))
+			importContext := BoolUI(fmt.Sprintf("Do you want to add context「%s」? (If you select `False`, this context will not be merged)", newName))
 			if importContext == "False" {
 				continue
 			}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -38,6 +39,7 @@ func (ac *AddCommand) Init() {
 	ac.command.Flags().StringP("file", "f", "", "Path to merge kubeconfig files")
 	ac.command.Flags().String("context-name", "", "override context name when add kubeconfig context")
 	ac.command.PersistentFlags().BoolP("cover", "c", false, "Overwrite local kubeconfig files")
+	ac.command.PersistentFlags().Bool("select-context", false, "select the context to be added")
 	_ = ac.command.MarkFlagRequired("file")
 	ac.AddCommands(&DocsCommand{})
 }
@@ -46,6 +48,7 @@ func (ac *AddCommand) runAdd(cmd *cobra.Command, args []string) error {
 	file, _ := ac.command.Flags().GetString("file")
 	cover, _ := ac.command.Flags().GetBool("cover")
 	contextName, _ := ac.command.Flags().GetString("context-name")
+	selectContext, _ := ac.command.Flags().GetBool("select-context")
 
 	var newConfig *clientcmdapi.Config
 	var err error
@@ -72,7 +75,7 @@ func (ac *AddCommand) runAdd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	err = AddToLocal(newConfig, file, contextName, cover)
+	err = AddToLocal(newConfig, file, contextName, cover, selectContext)
 	if err != nil {
 		return err
 	}
@@ -80,7 +83,7 @@ func (ac *AddCommand) runAdd(cmd *cobra.Command, args []string) error {
 }
 
 // AddToLocal add kubeConfig to local
-func AddToLocal(newConfig *clientcmdapi.Config, path, newName string, cover bool) error {
+func AddToLocal(newConfig *clientcmdapi.Config, path, newName string, cover bool, selectContext bool) error {
 	oldConfig, err := clientcmd.LoadFromFile(cfgFile)
 	if err != nil {
 		return err
@@ -90,7 +93,7 @@ func AddToLocal(newConfig *clientcmdapi.Config, path, newName string, cover bool
 		fileName: getFileName(path),
 	}
 	// merge context loop
-	outConfig, err := kco.handleContexts(oldConfig, newName)
+	outConfig, err := kco.handleContexts(oldConfig, newName, selectContext)
 	if err != nil {
 		return err
 	}
@@ -99,6 +102,12 @@ func AddToLocal(newConfig *clientcmdapi.Config, path, newName string, cover bool
 			outConfig.CurrentContext = k
 		}
 	}
+
+	if reflect.DeepEqual(oldConfig, outConfig) {
+		fmt.Println("No context to import. Skipping write kubeconfig.")
+		return nil
+	}
+
 	if !cover {
 		cover, err = strconv.ParseBool(BoolUI(fmt.Sprintf("Does it overwrite File 「%s」?", cfgFile)))
 		if err != nil {
@@ -112,7 +121,7 @@ func AddToLocal(newConfig *clientcmdapi.Config, path, newName string, cover bool
 	return nil
 }
 
-func (kc *KubeConfigOption) handleContexts(oldConfig *clientcmdapi.Config, contextName string) (*clientcmdapi.Config, error) {
+func (kc *KubeConfigOption) handleContexts(oldConfig *clientcmdapi.Config, contextName string, selectContext bool) (*clientcmdapi.Config, error) {
 	newConfig := clientcmdapi.NewConfig()
 	var index int
 	var newName string
@@ -129,8 +138,15 @@ func (kc *KubeConfigOption) handleContexts(oldConfig *clientcmdapi.Config, conte
 			newName = contextName
 		}
 
+		if selectContext {
+			importContext := BoolUI(fmt.Sprintf("Do you want to import context「%s」? (If you select `False`, this context will not be merged)", newName))
+			if importContext == "False" {
+				continue
+			}
+		}
+
 		if checkContextName(newName, oldConfig) {
-			nameConfirm := BoolUI(fmt.Sprintf("「%s」 Name already exists, do you want to rename it. (If you select `False`, this context will not be merged)", newName))
+			nameConfirm := BoolUI(fmt.Sprintf("「%s」 Name already exists, do you want to rename it? (If you select `False`, this context will not be merged)", newName))
 			if nameConfirm == "True" {
 				newName = PromptUI("Rename", newName)
 				if newName == kc.fileName {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -213,7 +213,7 @@ func TestKubeConfig_handleContexts(t *testing.T) {
 				config:   tt.fields.config,
 				fileName: tt.fields.fileName,
 			}
-			got, err := kc.handleContexts(tt.args.oldConfig, tt.args.newName)
+			got, err := kc.handleContexts(tt.args.oldConfig, tt.args.newName, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("handleContexts() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -265,7 +265,7 @@ func TestAddToLocal(t *testing.T) {
 	}
 
 	// Test AddToLocal function
-	err = AddToLocal(newConfig, tempFile.Name(), "", true)
+	err = AddToLocal(newConfig, tempFile.Name(), "", true, false)
 	if err != nil {
 		t.Fatalf("Failed to add to local: %v", err)
 	}

--- a/cmd/cloud_add.go
+++ b/cmd/cloud_add.go
@@ -36,6 +36,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 	clusterID, _ := ca.command.Flags().GetString("cluster_id")
 	regionID, _ := ca.command.Flags().GetString("region_id")
 	cover, _ := ca.command.Flags().GetBool("cover")
+	selectContext, _ := ca.command.Flags().GetBool("select-context")
 	var num int
 	if provider == "" {
 		num = selectCloud(Clouds, "Select Cloud")
@@ -74,7 +75,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			err = AddToLocal(newConfig, clusters[clusterNum].Name, "", cover)
+			err = AddToLocal(newConfig, clusters[clusterNum].Name, "", cover, selectContext)
 			if err != nil {
 				return err
 			}
@@ -87,7 +88,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			err = AddToLocal(newConfig, fmt.Sprintf("alicloud-%s", clusterID), "", cover)
+			err = AddToLocal(newConfig, fmt.Sprintf("alicloud-%s", clusterID), "", cover, selectContext)
 			if err != nil {
 				return err
 			}
@@ -127,7 +128,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			err = AddToLocal(newConfig, clusters[clusterNum].Name, "", cover)
+			err = AddToLocal(newConfig, clusters[clusterNum].Name, "", cover, selectContext)
 			if err != nil {
 				return err
 			}
@@ -140,7 +141,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			err = AddToLocal(newConfig, fmt.Sprintf("tencent-%s", clusterID), "", cover)
+			err = AddToLocal(newConfig, fmt.Sprintf("tencent-%s", clusterID), "", cover, selectContext)
 			if err != nil {
 				return err
 			}
@@ -169,7 +170,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			err = AddToLocal(newConfig, clusters[clusterNum].Name, "", cover)
+			err = AddToLocal(newConfig, clusters[clusterNum].Name, "", cover, selectContext)
 			if err != nil {
 				return err
 			}
@@ -182,7 +183,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			err = AddToLocal(newConfig, fmt.Sprintf("rancher-%s", clusterID), "", cover)
+			err = AddToLocal(newConfig, fmt.Sprintf("rancher-%s", clusterID), "", cover, selectContext)
 			if err != nil {
 				return err
 			}
@@ -219,7 +220,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 		if err != nil {
 			return err
 		}
-		err = AddToLocal(newConfig, fmt.Sprintf("aws-%s", clusterID), "", cover)
+		err = AddToLocal(newConfig, fmt.Sprintf("aws-%s", clusterID), "", cover, selectContext)
 		if err != nil {
 			return err
 		}
@@ -279,7 +280,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return err
 			}
-			return AddToLocal(newConfig, fmt.Sprintf("azure-%s", clusterID), "", cover)
+			return AddToLocal(newConfig, fmt.Sprintf("azure-%s", clusterID), "", cover, selectContext)
 		}
 
 		subscriptionList, err := azure.ListSubscriptions()
@@ -332,7 +333,7 @@ func (ca *CloudAddCommand) runCloudAdd(cmd *cobra.Command, args []string) error 
 		if err != nil {
 			return err
 		}
-		return AddToLocal(newConfig, fmt.Sprintf("azure-%s", clusterID), "", cover)
+		return AddToLocal(newConfig, fmt.Sprintf("azure-%s", clusterID), "", cover, selectContext)
 
 	}
 	return nil

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -70,7 +70,7 @@ func (mc MergeCommand) runMerge(command *cobra.Command, args []string) error {
 	}
 
 	if len(outConfigs.Contexts) == 0 {
-		fmt.Println("No context to import. Skipping write kubeconfig.")
+		fmt.Println("No context to merge.")
 		return nil
 	}
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -30,6 +30,7 @@ func (mc *MergeCommand) Init() {
 	}
 	mc.command.Flags().StringP("folder", "f", "", "KubeConfig folder")
 	mc.command.Flags().BoolP("assumeyes", "y", false, "skip interactive file overwrite confirmation")
+	mc.command.PersistentFlags().Bool("select-context", false, "select the context to be merged")
 	//_ = mc.command.MarkFlagRequired("folder")
 	mc.AddCommands(&DocsCommand{})
 }
@@ -37,6 +38,8 @@ func (mc *MergeCommand) Init() {
 func (mc MergeCommand) runMerge(command *cobra.Command, args []string) error {
 	files := args
 	folder, _ := mc.command.Flags().GetString("folder")
+	selectContext, _ := mc.command.Flags().GetBool("select-context")
+
 	if folder != "" {
 		folder, err := CheckAndTransformFilePath(folder)
 		if err != nil {
@@ -60,11 +63,17 @@ func (mc MergeCommand) runMerge(command *cobra.Command, args []string) error {
 			config:   loadConfig,
 			fileName: getFileName(yaml),
 		}
-		outConfigs, err = kco.handleContexts(outConfigs, "")
+		outConfigs, err = kco.handleContexts(outConfigs, "", selectContext)
 		if err != nil {
 			return err
 		}
 	}
+
+	if len(outConfigs.Contexts) == 0 {
+		fmt.Println("No context to import. Skipping write kubeconfig.")
+		return nil
+	}
+
 	confirm, _ := mc.command.Flags().GetBool("assumeyes")
 	if !confirm {
 		cover := BoolUI(fmt.Sprintf("Are you sure you want to overwrite the 「%s」 file?", cfgFile))

--- a/docs/en-us/cli/kubecm_add.md
+++ b/docs/en-us/cli/kubecm_add.md
@@ -34,6 +34,7 @@ cat /etc/kubernetes/admin.conf |  kubecm add -f -
   -c, --cover                 Overwrite local kubeconfig files
   -f, --file string           Path to merge kubeconfig files
   -h, --help                  help for add
+      --select-context        select the context to be added
 ```
 
 ### Options inherited from parent commands

--- a/docs/en-us/cli/kubecm_merge.md
+++ b/docs/en-us/cli/kubecm_merge.md
@@ -29,6 +29,7 @@ kubecm merge -f dir --config kubecm.config
   -y, --assumeyes       skip interactive file overwrite confirmation
   -f, --folder string   KubeConfig folder
   -h, --help            help for merge
+      --select-context  select the context to be merged
 ```
 
 ### Options inherited from parent commands

--- a/docs/zh-cn/cli/kubecm_add.md
+++ b/docs/zh-cn/cli/kubecm_add.md
@@ -35,6 +35,7 @@ cat /etc/kubernetes/admin.conf |  kubecm add -f -
   -f, --file string   Path to merge kubeconfig files
   
   -h, --help          help for add
+  --select-context    select the context to be added
 ```
 
 ### 全局选项

--- a/docs/zh-cn/cli/kubecm_merge.md
+++ b/docs/zh-cn/cli/kubecm_merge.md
@@ -29,6 +29,7 @@ kubecm merge -f dir --config kubecm.config
   -y, --assumeyes       skip interactive file overwrite confirmation
   -f, --folder string   KubeConfig folder
   -h, --help            help for merge
+  --select-context      select the context to be merged
 ```
 
 ### 全局选项


### PR DESCRIPTION
## Description

Add the `--select-context` parameter allowing the user to choose which context should be added when running the `kubecm add` and `kubecm merge` commands.

## Test

Prepare two kubeconfig.
```bash
./kubecm list --config kubeconfig1
+------------+-------------+-------------+----------+-------------------------+--------------+
|   CURRENT  |     NAME    |   CLUSTER   |   USER   |          SERVER         |   Namespace  |
+============+=============+=============+==========+=========================+==============+
|      *     |   context1  |   cluster1  |   user1  |   https://example1.com  |    default   |
+------------+-------------+-------------+----------+-------------------------+--------------+

./kubecm list --config kubeconfig2
+------------+-------------+-------------+----------+-------------------------+--------------+
|   CURRENT  |     NAME    |   CLUSTER   |   USER   |          SERVER         |   Namespace  |
+============+=============+=============+==========+=========================+==============+
|      *     |   context2  |   cluster2  |   user2  |   https://example2.com  |    default   |
+------------+-------------+-------------+----------+-------------------------+--------------+
|            |   context3  |   cluster3  |   user3  |   https://example3.com  |    default   |
+------------+-------------+-------------+----------+-------------------------+--------------+
|            |   context4  |   cluster4  |   user4  |   https://example4.com  |    default   |
+------------+-------------+-------------+----------+-------------------------+--------------+
```

Run the `kubecm add` command with the `--select-context` parameter. The user needs to confirm each context to be imported. If the `--select-context` parameter is omitted, confirmation is not required.

```bash
./kubecm add --config kubeconfig1 -f kubeconfig2 --select-context
```
[![asciicast](https://asciinema.org/a/659955.svg)](https://asciinema.org/a/659955)

Run the `kubecm merge` command with the `--select-context` parameter.
```bash
./kubecm merge --config output  kubeconfig1 kubeconfig2 --select-context
```
[![asciicast](https://asciinema.org/a/659958.svg)](https://asciinema.org/a/659958)

If there is no context to add or merge, the program ends directly instead of asking `Does it overwrite File xxx ?`.
[![asciicast](https://asciinema.org/a/659960.svg)](https://asciinema.org/a/659960)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [ ] I have added/updated unit or e2e tests to cover my changes.
- [x] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
