### PR TITLE
add KUBECM_DISABLE_K8S_MORE_INFO env to disable output moreinfo

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -96,5 +96,7 @@ kubecm ls
 kubecm l
 # Filter out keywords(Multi-keyword support)
 kubecm ls kind k3s
+# Useful environment variables
+KUBECM_DISABLE_K8S_MORE_INFO: it will disable the k8s more info in the output
 `
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,8 +57,7 @@ func (lc *ListCommand) runList(command *cobra.Command, args []string) error {
 		printString(os.Stdout, "\nKubernetes version ")
 		printYellow(os.Stdout, clusterMessage.Version.GitVersion)
 		printService(os.Stdout, "\nKubernetes master", clusterMessage.Config.Host)
-		err = MoreInfo(clusterMessage.ClientSet, os.Stdout)
-		if err != nil {
+		if err := MoreInfo(clusterMessage.ClientSet, os.Stdout); err != nil {
 			fmt.Println("(Error reporting can be ignored and does not affect usage.)")
 		}
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -289,6 +289,9 @@ func ClusterStatus(duration time.Duration) (*ClusterStatusCheck, error) {
 
 // MoreInfo output more info
 func MoreInfo(clientSet kubernetes.Interface, writer io.Writer) error {
+	if os.Getenv("KUBECM_DISABLE_K8S_MORE_INFO") != "" {
+		return nil
+	}
 	timeout := int64(2)
 	ctx := context.TODO()
 	nodesList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{TimeoutSeconds: &timeout})


### PR DESCRIPTION
## Description

<!--- Please provide a detailed description of your pull request. It should include enough information to help reviewers understand the content and purpose of the PR. -->

## Related Issue

<!--- If this PR relates to any open issues, please reference them here. For example: resolves #123 -->
resolves https://github.com/sunny0826/kubecm/issues/972

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [ ] I have added/updated unit or e2e tests to cover my changes.
- [ ] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
