### PR TITLE
feat(cmd): add non-interactively mode to rename command

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -107,6 +107,10 @@ jobs:
           export KUBECONFIG="$PWD/multi.config"
           bin/kubecm s kind-2nd-kind
           echo "********************************************************************************"
+          echo "Running kubecm rename..."
+          echo "********************************************************************************"
+          bin/kubecm rename kind-2nd-kind kind-2nd-kind-new      
+          echo "********************************************************************************"
           echo "Running kubecm create..."
           echo "********************************************************************************"
           bin/kubecm create --user e2e --namespace default --cluster-role view --context-name kind-2nd-kind

--- a/docs/en-us/cli/kubecm_rename.md
+++ b/docs/en-us/cli/kubecm_rename.md
@@ -16,6 +16,8 @@ kubecm rename [flags]
 
 # Renamed the context interactively
 kubecm rename
+# Renamed the context non-interactively
+kubecm rename <kube-context-name> <new-kube-context-name>
 
 ```
 


### PR DESCRIPTION
## Description

<!--- Please provide a detailed description of your pull request. It should include enough information to help reviewers understand the content and purpose of the PR. -->
add non-interactively mode to rename command

## Related Issue

<!--- If this PR relates to any open issues, please reference them here. For example: resolves #123 -->
resolves #993 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [x] I have added/updated unit or e2e tests to cover my changes.
- [x] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
