### PR TITLE
Sort contexts before listing them

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -112,6 +113,7 @@ func selectDeleteContext(config *clientcmdapi.Config) (string, string, error) {
 			kubeItems = append([]Needle{{Name: key, Cluster: obj.Cluster, User: obj.AuthInfo, Center: "(*)"}}, kubeItems...)
 		}
 	}
+	slices.SortFunc(kubeItems, compareKubeItems)
 	// exit option
 	kubeItems, err := ExitOption(kubeItems)
 	if err != nil {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"slices"
+
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -93,6 +95,7 @@ func selectExportContext(config *clientcmdapi.Config) (string, string, error) {
 			kubeItems = append([]Needle{{Name: key, Cluster: obj.Cluster, User: obj.AuthInfo, Center: "(*)"}}, kubeItems...)
 		}
 	}
+	slices.SortFunc(kubeItems, compareKubeItems)
 	// exit option
 	kubeItems, err := ExitOption(kubeItems)
 	if err != nil {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,6 +43,7 @@ func (rc *RenameCommand) runRename(command *cobra.Command, args []string) error 
 			kubeItems = append([]Needle{{Name: key, Cluster: obj.Cluster, User: obj.AuthInfo, Center: "(*)"}}, kubeItems...)
 		}
 	}
+	slices.SortFunc(kubeItems, compareKubeItems)
 	var kubeName string
 	var rename string
 	// args option

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -81,6 +82,7 @@ func handleOperation(config *clientcmdapi.Config) (*clientcmdapi.Config, error) 
 			kubeItems = append([]Needle{{Name: key, Cluster: obj.Cluster, User: obj.AuthInfo, Center: "(*)"}}, kubeItems...)
 		}
 	}
+	slices.SortFunc(kubeItems, compareKubeItems)
 	// exit option
 	kubeItems, err := ExitOption(kubeItems)
 	if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -452,6 +452,10 @@ func CheckAndTransformFilePath(path string, autoCreate bool) (string, error) {
 	return path, nil
 }
 
+func compareKubeItems(a, b Needle) int {
+	return strings.Compare(a.Name, b.Name)
+}
+
 // CheckValidContext check and clean mismatched AuthInfo and Cluster
 func CheckValidContext(clear bool, config *clientcmdapi.Config) *clientcmdapi.Config {
 	for key, obj := range config.Contexts {


### PR DESCRIPTION
It was annoying to have a different order for the context every time I ran `kubecm switch`
## Checklist

- [X] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
