### PR TITLE
fix: cluster and user name conflict on add kubeconfig with same context cluster and user

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -245,7 +246,7 @@ func (kc *KubeConfigOption) handleContext(oldConfig *clientcmdapi.Config,
 
 	isClusterNameExist, isUserNameExist := checkClusterAndUserName(oldConfig, ctx.Cluster, ctx.AuthInfo)
 	newConfig := clientcmdapi.NewConfig()
-	suffix := HashSufString(name)
+	suffix := rand.String(10)
 
 	if isClusterNameExist {
 		clusterNameSuffix = "-" + suffix
@@ -278,7 +279,7 @@ func (kc *KubeConfigOption) handleContext(oldConfig *clientcmdapi.Config,
 func addExample() string {
 	return `
 # Merge test.yaml with $HOME/.kube/config
-kubecm add -f test.yaml 
+kubecm add -f test.yaml
 # Merge test.yaml with $HOME/.kube/config and add a prefix before context name
 kubecm add -cf test.yaml --context-prefix test
 # Merge test.yaml with $HOME/.kube/config and define the attributes used for composing the context name


### PR DESCRIPTION

## Description

See issue #1047 and Files changed.

## Related Issue

resolves #1047 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [ ] I have added/updated unit or e2e tests to cover my changes.
- [ ] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
