### PR TITLE
feat: add fuzzy search

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/lithammer/fuzzysearch/fuzzy"
 	"io"
 	"log"
 	"os"
@@ -184,7 +185,7 @@ func selectUIRunner(kubeItems []Needle, label string, runner SelectRunner) (int,
 		if input == "q" && name == "<exit>" {
 			return true
 		}
-		return strings.Contains(name, input)
+		return fuzzy.Match(input, name)
 	}
 	prompt := promptui.Select{
 		Label:     label,


### PR DESCRIPTION
## Description

<!--- Please provide a detailed description of your pull request. It should include enough information to help reviewers understand the content and purpose of the PR. -->

I need to switch k8s contexts frequently at work, using `kubecm switch`, which works well, but doesn't support fuzzy searches, and I need to remember exactly what each context name is when there are too many contexts, so I'm submitting this pr.

It should be noted that my `kubecm` is modified, and I'll show you an example of fuzzy search.

<img width="2560" alt="image" src="https://github.com/user-attachments/assets/9c55a5c6-4dcc-4f07-8f38-749c05e9a1cc" />


Before:
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/73feba39-1bb7-4a32-8ad9-b390dcd23e63" />

After:
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/8266004b-8611-4c15-af0f-9f261c44243b" />







## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [x] I have added/updated unit or e2e tests to cover my changes.
- [ ] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
