### PR TITLE
chore(go-version): Bump golang version from 1.22.2 to 1.24.2

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v1.54
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.4.0

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          version: v1.64
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.4.0

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -133,7 +133,7 @@ func selectNamespaceWithRunner(namespaces []Namespaces, runner SelectRunner) (in
 func GetClientSet(configFile string) (kubernetes.Interface, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", configFile)
 	if err != nil {
-		return nil, fmt.Errorf(err.Error())
+		return nil, fmt.Errorf("failed to build config: %s", err.Error())
 	}
 	return kubernetes.NewForConfig(config)
 }
@@ -143,7 +143,7 @@ func GetNamespaceList(currentNamespace string, clientset kubernetes.Interface) (
 	var nss []Namespaces
 	namespaceList, err := clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf(err.Error())
+		return nil, fmt.Errorf("failed to list namespaces: %s", err.Error())
 	}
 	for _, specItem := range namespaceList.Items {
 		switch currentNamespace {
@@ -168,7 +168,7 @@ func GetNamespaceList(currentNamespace string, clientset kubernetes.Interface) (
 func CheckNamespaceExist(namespace string, clientset kubernetes.Interface) (bool, error) {
 	ns, err := clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 	if err != nil {
-		return false, fmt.Errorf(err.Error())
+		return false, fmt.Errorf("failed to get namespace %s: %s", namespace, err.Error())
 	}
 	if ns.Name == namespace {
 		return true, nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sunny0826/kubecm
 
-go 1.22.2
+go 1.24.2
 
 require (
 	github.com/alibabacloud-go/cs-20151215/v2 v2.4.5
@@ -32,6 +32,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0
 	github.com/aws/aws-sdk-go v1.50.35
+	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
@@ -78,7 +79,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -119,7 +119,7 @@ func (a *AWS) GetKubeConfigObj(clusterID string) (*clientcmdapi.Config, error) {
 	}
 
 	decodePem, err := base64.StdEncoding.DecodeString(*cluster.Cluster.CertificateAuthority.Data)
-	if err != nil {
+	if err != nil || string(decodePem) == "" {
 		return nil, err
 	}
 

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
+	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 )
 
 // Azure struct of azure cloud


### PR DESCRIPTION
## Description

Bump golang version to latest.

## Related Issue

<!--- If this PR relates to any open issues, please reference them here. For example: resolves #123 -->

https://github.com/sunny0826/kubecm/issues/1083

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [x] I have added/updated unit or e2e tests to cover my changes.
- [ ] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
