### PR TITLE
Make "kubecm ls" look better

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/lithammer/fuzzysearch/fuzzy"
 	"io"
 	"log"
 	"os"
@@ -15,8 +16,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/lithammer/fuzzysearch/fuzzy"
 
 	"k8s.io/client-go/rest"
 


### PR DESCRIPTION
## Description

I analyzed the current dependency library for the output table, "github.com/bndr/gotabulate". This library is relatively simple with few dependencies, which is sufficient for the kubecm ls scenario.

However, the output has many gaps and dotted lines, making it aesthetically unappealing. The gotabulate library doesn't allow for custom output formatting, and other similar Go libraries have many dependencies, making a change unnecessary.

Therefore, my solution is to replace the table output by gotabulate with a Unicode string before the stdout output.

Specific code changes: 
1. Add a function `beautifyStdoutTable` at the end of the `utils.go` file. 
2. Modify the `PrintTable` function in the `utils.go` file to call `beautifyStdoutTable`.

The advantages are: no dependencies changed, the output is much more aesthetically pleasing, the logic is simple and clear, and bugs are easier to find and fix.

I also analyzed Unicode compatibility, and there shouldn't be any problems.

## Related Issue

resolves #1148 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes only affecting documentation)

## Checklist

- [x] I have tested my changes locally and ensured they are functioning properly.  Please run the `make build` and `make test` commands.
- [ ] I have added/updated unit or e2e tests to cover my changes.
- [ ] I have updated the relevant documentation. If you change commands or arguments, run `make doc-gen` to generate new documentation.
