### PR TITLE
docs: add Registry to README highlights and sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Source binary:
 - **Context Management**: Switch between Kubernetes **clusters** and **namespaces** in a single command.
 - **Merge-Kubeconfig**: Merge multiple kubeconfig files into one.
 - **Interactive Mode**: Interactively select the context you want to switch to.
+- **Registry**: Distribute kubeconfigs across teams using a [Git-backed registry](https://kubecm.cloud/en-us/registry).
 - **Multi-Platform**: Support Linux, macOS, and Windows.
 - **Auto-Completion**: Support auto-completion for Bash, Zsh, and Fish.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ Available Commands:
   list        List KubeConfig
   merge       Merge multiple kubeconfig files into one
   namespace   Switch or change namespace interactively
+  registry    Git-backed kubeconfig distribution for teams
   rename      Rename the contexts of kubeconfig
   switch      Switch Kube Context interactively
   version     Print version info

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,8 +1,10 @@
 * [Install](/en-us/install.md)
 * [Introduction](/en-us/introduction.md)
+* [Registry](/en-us/registry.md)
 * CLI References
     * [kubecm add](/en-us/cli/kubecm_add.md)
     * [kubecm alias](/en-us/cli/kubecm_alias.md)
+    * [kubecm cloud](/en-us/cli/kubecm_cloud.md)
     * [kubecm completion](/en-us/cli/kubecm_completion.md)
     * [kubecm delete](/en-us/cli/kubecm_delete.md)
     * [kubecm list](/en-us/cli/kubecm_list.md)
@@ -12,3 +14,4 @@
     * [kubecm switch](/en-us/cli/kubecm_switch.md)
     * [kubecm version](/en-us/cli/kubecm_version.md)
     * [kubecm export](/en-us/cli/kubecm_export.md)
+    * [kubecm registry](/en-us/cli/kubecm_registry.md)


### PR DESCRIPTION
## Summary

- Add **Registry** to the highlights section in `README.md`
- Add missing entries (`Registry`, `cloud`, `registry`) to `docs/_sidebar.md` (root sidebar used by Docsify — the `docs/en-us/_sidebar.md` was already updated but Docsify uses the root one)
- Add `registry` command to `docs/README.md` available commands list

Closes the request from https://github.com/sunny0826/kubecm/pull/1171#issuecomment-2683857648