### PR TITLE
fix(namespace): handle missing or empty current-context gracefully

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -52,7 +52,14 @@ func (nc *NamespaceCommand) runNamespace(command *cobra.Command, args []string) 
 	}
 
 	currentContext := config.CurrentContext
-	currentNamespace := config.Contexts[currentContext].Namespace
+	if currentContext == "" {
+		return fmt.Errorf("current-context is not set")
+	}
+	ctx, ok := config.Contexts[currentContext]
+	if !ok {
+		return fmt.Errorf("context %q not found in kubeconfig", currentContext)
+	}
+	currentNamespace := ctx.Namespace
 	clientset, err := GetClientSet(kubeconfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Fix a nil pointer panic in `namespace` command when `current-context` is missing or empty in the kubeconfig
- Return a clear error message instead of crashing

## Test plan

- [x] `kubecm namespace` with a kubeconfig that has no `current-context` set
- [x] `kubecm namespace` with a kubeconfig where `current-context` points to a non-existent context
- [x] `kubecm namespace` with a valid kubeconfig (no regression)