### PR TITLE
feat(registry): add User concept, cluster/user separation

### DIFF
--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -143,18 +143,43 @@ func LoadRole(repoDir, roleName string) (*Role, error) {
 	return &role, nil
 }
 
-// LoadFragment reads fragments/<name>.yaml from a cloned registry repo.
-func LoadFragment(repoDir, fragmentName string) (*Fragment, error) {
-	path := filepath.Join(repoDir, "fragments", fragmentName+".yaml")
+// LoadCluster reads clusters/<name>.yaml from a cloned registry repo.
+// Falls back to fragments/<name>.yaml for backward compatibility.
+func LoadCluster(repoDir, clusterName string) (*Cluster, error) {
+	path := filepath.Join(repoDir, "clusters", clusterName+".yaml")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading fragment %q: %w", fragmentName, err)
+		// Fallback to legacy fragments/ directory
+		path = filepath.Join(repoDir, "fragments", clusterName+".yaml")
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading cluster %q: %w", clusterName, err)
+		}
 	}
-	var frag Fragment
-	if err := yaml.Unmarshal(data, &frag); err != nil {
-		return nil, fmt.Errorf("parsing fragment %q: %w", fragmentName, err)
+	var cl Cluster
+	if err := yaml.Unmarshal(data, &cl); err != nil {
+		return nil, fmt.Errorf("parsing cluster %q: %w", clusterName, err)
 	}
-	return &frag, nil
+	return &cl, nil
+}
+
+// LoadFragment is a deprecated alias for LoadCluster.
+func LoadFragment(repoDir, fragmentName string) (*Fragment, error) {
+	return LoadCluster(repoDir, fragmentName)
+}
+
+// LoadUser reads users/<name>.yaml from a cloned registry repo.
+func LoadUser(repoDir, userName string) (*User, error) {
+	path := filepath.Join(repoDir, "users", userName+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading user %q: %w", userName, err)
+	}
+	var u User
+	if err := yaml.Unmarshal(data, &u); err != nil {
+		return nil, fmt.Errorf("parsing user %q: %w", userName, err)
+	}
+	return &u, nil
 }
 
 func homeDir() (string, error) {

--- a/pkg/registry/resolve_test.go
+++ b/pkg/registry/resolve_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+// --- Tests using deprecated Fragment aliases (backward compat) ---
+
 func TestResolveFragment_Static(t *testing.T) {
 	frag := &Fragment{
 		Metadata: RegistryMetadata{Name: "test-static"},
@@ -93,4 +95,190 @@ func TestResolveFragment_AzureMissingSection(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for azure fragment without azure section")
 	}
+}
+
+func TestResolveFragmentWithUser_Nil(t *testing.T) {
+	frag := &Fragment{
+		Metadata:   RegistryMetadata{Name: "test"},
+		Provider:   "static",
+		Kubeconfig: staticKubeconfig("https://k8s:6443", "original-token"),
+	}
+
+	cfg, err := ResolveFragmentWithUser(frag, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AuthInfos["test-cluster"].Token != "original-token" {
+		t.Errorf("token = %q, want %q", cfg.AuthInfos["test-cluster"].Token, "original-token")
+	}
+}
+
+func TestResolveFragmentWithUser_StaticOverride(t *testing.T) {
+	frag := &Fragment{
+		Metadata:   RegistryMetadata{Name: "test"},
+		Provider:   "static",
+		Kubeconfig: staticKubeconfig("https://k8s:6443", "tok"),
+	}
+	user := &User{
+		Metadata: RegistryMetadata{Name: "test-user"},
+		Provider: "static",
+	}
+
+	cfg, err := ResolveFragmentWithUser(frag, user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.Clusters["test-cluster"]; !ok {
+		t.Error("expected cluster 'test-cluster' in config")
+	}
+}
+
+func TestResolveFragmentWithUser_ProviderMismatch(t *testing.T) {
+	frag := &Fragment{
+		Metadata: RegistryMetadata{Name: "aws-frag"},
+		Provider: "aws",
+		AWS:      &AWSFragment{Region: "eu-west-1", Cluster: "test"},
+	}
+	user := &User{
+		Metadata: RegistryMetadata{Name: "azure-user"},
+		Provider: "azure",
+	}
+
+	_, err := ResolveFragmentWithUser(frag, user)
+	if err == nil {
+		t.Error("expected error for provider mismatch")
+	}
+}
+
+func TestCloneFragment_NoMutation(t *testing.T) {
+	orig := &Fragment{
+		Metadata: RegistryMetadata{Name: "orig"},
+		Provider: "aws",
+		AWS: &AWSFragment{
+			Region:  "eu-west-1",
+			Cluster: "test",
+			Profile: "original-profile",
+		},
+	}
+
+	clone := cloneCluster(orig)
+	clone.AWS.Profile = "new-profile"
+	clone.Metadata.Name = "clone"
+
+	if orig.AWS.Profile != "original-profile" {
+		t.Errorf("original AWS profile mutated: got %q", orig.AWS.Profile)
+	}
+	if orig.Metadata.Name != "orig" {
+		t.Errorf("original metadata mutated: got %q", orig.Metadata.Name)
+	}
+}
+
+func TestCloneFragment_AzureNoMutation(t *testing.T) {
+	orig := &Fragment{
+		Metadata: RegistryMetadata{Name: "orig"},
+		Provider: "azure",
+		Azure: &AzureFragment{
+			SubscriptionID: "sub-123",
+			ResourceGroup:  "rg",
+			Cluster:        "aks",
+			TenantID:       "original-tenant",
+		},
+	}
+
+	clone := cloneCluster(orig)
+	clone.Azure.TenantID = "new-tenant"
+
+	if orig.Azure.TenantID != "original-tenant" {
+		t.Errorf("original Azure tenantID mutated: got %q", orig.Azure.TenantID)
+	}
+}
+
+// --- Tests using new Cluster types (new API) ---
+
+func TestResolveCluster_Static(t *testing.T) {
+	cl := &Cluster{
+		Metadata: RegistryMetadata{Name: "test-static"},
+		Provider: "static",
+		Kubeconfig: staticKubeconfig("https://k8s.internal:6443", "test-token"),
+	}
+
+	cfg, err := ResolveCluster(cl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.Clusters["test-cluster"]; !ok {
+		t.Error("expected cluster 'test-cluster' in config")
+	}
+}
+
+func TestResolveClusterWithUser_Nil(t *testing.T) {
+	cl := &Cluster{
+		Metadata:   RegistryMetadata{Name: "test"},
+		Provider:   "static",
+		Kubeconfig: staticKubeconfig("https://k8s:6443", "original-token"),
+	}
+
+	cfg, err := ResolveClusterWithUser(cl, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AuthInfos["test-cluster"].Token != "original-token" {
+		t.Errorf("token = %q, want %q", cfg.AuthInfos["test-cluster"].Token, "original-token")
+	}
+}
+
+func TestResolveClusterWithUser_ProviderMismatch(t *testing.T) {
+	cl := &Cluster{
+		Metadata: RegistryMetadata{Name: "aws-cl"},
+		Provider: "aws",
+		AWS:      &AWSClusterConfig{Region: "eu-west-1", Cluster: "test"},
+	}
+	user := &User{
+		Metadata: RegistryMetadata{Name: "azure-user"},
+		Provider: "azure",
+	}
+
+	_, err := ResolveClusterWithUser(cl, user)
+	if err == nil {
+		t.Error("expected error for provider mismatch")
+	}
+}
+
+func TestCloneCluster_NoMutation(t *testing.T) {
+	orig := &Cluster{
+		Metadata: RegistryMetadata{Name: "orig"},
+		Provider: "aws",
+		AWS: &AWSClusterConfig{
+			Region:  "eu-west-1",
+			Cluster: "test",
+			Profile: "original-profile",
+		},
+	}
+
+	clone := cloneCluster(orig)
+	clone.AWS.Profile = "new-profile"
+
+	if orig.AWS.Profile != "original-profile" {
+		t.Errorf("original AWS profile mutated: got %q", orig.AWS.Profile)
+	}
+}
+
+// staticKubeconfig returns a minimal valid kubeconfig YAML for testing.
+func staticKubeconfig(server, token string) string {
+	return `apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: ` + server + `
+    name: test-cluster
+contexts:
+  - context:
+      cluster: test-cluster
+      user: test-cluster
+    name: test-cluster
+users:
+  - name: test-cluster
+    user:
+      token: ` + token + `
+`
 }

--- a/pkg/registry/template.go
+++ b/pkg/registry/template.go
@@ -13,7 +13,7 @@ func ResolveTemplate(text string, vars map[string]string) (string, error) {
 		return text, nil
 	}
 
-	tmpl, err := template.New("fragment").Option("missingkey=error").Parse(text)
+	tmpl, err := template.New("cluster").Option("missingkey=error").Parse(text)
 	if err != nil {
 		return "", fmt.Errorf("parsing template: %w", err)
 	}
@@ -25,46 +25,74 @@ func ResolveTemplate(text string, vars map[string]string) (string, error) {
 	return buf.String(), nil
 }
 
-// ResolveFragmentTemplates applies template variables to all string fields in a Fragment.
-func ResolveFragmentTemplates(frag *Fragment, vars map[string]string) error {
+// ResolveClusterTemplates applies template variables to all string fields in a Cluster.
+func ResolveClusterTemplates(cl *Cluster, vars map[string]string) error {
 	if len(vars) == 0 {
 		return nil
 	}
 
 	var err error
 
-	if frag.AWS != nil {
-		if frag.AWS.Region, err = ResolveTemplate(frag.AWS.Region, vars); err != nil {
+	if cl.AWS != nil {
+		if cl.AWS.Region, err = ResolveTemplate(cl.AWS.Region, vars); err != nil {
 			return fmt.Errorf("aws.region: %w", err)
 		}
-		if frag.AWS.Cluster, err = ResolveTemplate(frag.AWS.Cluster, vars); err != nil {
+		if cl.AWS.Cluster, err = ResolveTemplate(cl.AWS.Cluster, vars); err != nil {
 			return fmt.Errorf("aws.cluster: %w", err)
 		}
-		if frag.AWS.Profile, err = ResolveTemplate(frag.AWS.Profile, vars); err != nil {
+		if cl.AWS.Profile, err = ResolveTemplate(cl.AWS.Profile, vars); err != nil {
 			return fmt.Errorf("aws.profile: %w", err)
 		}
 	}
 
-	if frag.Azure != nil {
-		if frag.Azure.SubscriptionID, err = ResolveTemplate(frag.Azure.SubscriptionID, vars); err != nil {
+	if cl.Azure != nil {
+		if cl.Azure.SubscriptionID, err = ResolveTemplate(cl.Azure.SubscriptionID, vars); err != nil {
 			return fmt.Errorf("azure.subscriptionId: %w", err)
 		}
-		if frag.Azure.ResourceGroup, err = ResolveTemplate(frag.Azure.ResourceGroup, vars); err != nil {
+		if cl.Azure.ResourceGroup, err = ResolveTemplate(cl.Azure.ResourceGroup, vars); err != nil {
 			return fmt.Errorf("azure.resourceGroup: %w", err)
 		}
-		if frag.Azure.Cluster, err = ResolveTemplate(frag.Azure.Cluster, vars); err != nil {
+		if cl.Azure.Cluster, err = ResolveTemplate(cl.Azure.Cluster, vars); err != nil {
 			return fmt.Errorf("azure.cluster: %w", err)
 		}
-		if frag.Azure.TenantID, err = ResolveTemplate(frag.Azure.TenantID, vars); err != nil {
+		if cl.Azure.TenantID, err = ResolveTemplate(cl.Azure.TenantID, vars); err != nil {
 			return fmt.Errorf("azure.tenantId: %w", err)
 		}
 	}
 
-	if frag.Kubeconfig != "" {
-		if frag.Kubeconfig, err = ResolveTemplate(frag.Kubeconfig, vars); err != nil {
+	if cl.Kubeconfig != "" {
+		if cl.Kubeconfig, err = ResolveTemplate(cl.Kubeconfig, vars); err != nil {
 			return fmt.Errorf("kubeconfig: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// ResolveUserTemplates applies template variables to all string fields in a User.
+func ResolveUserTemplates(u *User, vars map[string]string) error {
+	if len(vars) == 0 {
+		return nil
+	}
+
+	var err error
+
+	if u.AWS != nil {
+		if u.AWS.Profile, err = ResolveTemplate(u.AWS.Profile, vars); err != nil {
+			return fmt.Errorf("aws.profile: %w", err)
+		}
+	}
+
+	if u.Azure != nil {
+		if u.Azure.TenantID, err = ResolveTemplate(u.Azure.TenantID, vars); err != nil {
+			return fmt.Errorf("azure.tenantId: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ResolveFragmentTemplates is a deprecated alias for ResolveClusterTemplates.
+func ResolveFragmentTemplates(cl *Cluster, vars map[string]string) error {
+	return ResolveClusterTemplates(cl, vars)
 }

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -24,40 +24,97 @@ type VariableSpec struct {
 	Default     string `yaml:"default,omitempty"`
 }
 
-// Role is a roles/<name>.yaml file listing fragments for a team role.
+// Role is a roles/<name>.yaml file listing clusters for a team role.
 type Role struct {
 	APIVersion    string           `yaml:"apiVersion"`
 	Kind          string           `yaml:"kind"`
 	Metadata      RegistryMetadata `yaml:"metadata"`
 	ContextPrefix string           `yaml:"contextPrefix,omitempty"`
-	Fragments     []string         `yaml:"fragments"`
+	Fragments     []string         `yaml:"fragments,omitempty"` // legacy format
+	Contexts      []RoleContext    `yaml:"contexts,omitempty"`
 }
 
-// Fragment is a fragments/<name>.yaml file describing one cluster.
-type Fragment struct {
+// RoleContext associates a cluster with an optional user override.
+type RoleContext struct {
+	Cluster  string `yaml:"cluster,omitempty"`
+	Fragment string `yaml:"fragment,omitempty"` // deprecated: use cluster
+	User     string `yaml:"user,omitempty"`
+	Name     string `yaml:"name,omitempty"`
+}
+
+// ClusterRef returns the cluster name, supporting both the new cluster:
+// field and the deprecated fragment: field for backward compatibility.
+func (rc *RoleContext) ClusterRef() string {
+	if rc.Cluster != "" {
+		return rc.Cluster
+	}
+	return rc.Fragment
+}
+
+// NormalizedContexts returns the role's contexts list.
+// If the new contexts: format is used, it is returned as-is.
+// Otherwise the legacy fragments: list is converted.
+func (r *Role) NormalizedContexts() []RoleContext {
+	if len(r.Contexts) > 0 {
+		return r.Contexts
+	}
+	result := make([]RoleContext, len(r.Fragments))
+	for i, f := range r.Fragments {
+		result[i] = RoleContext{Cluster: f}
+	}
+	return result
+}
+
+// User is a users/<name>.yaml file describing authentication credentials.
+type User struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   RegistryMetadata `yaml:"metadata"`
+	Provider   string           `yaml:"provider"`
+	AWS        *AWSUserConfig   `yaml:"aws,omitempty"`
+	Azure      *AzureUserConfig `yaml:"azure,omitempty"`
+}
+
+// AWSUserConfig holds AWS-specific user settings.
+type AWSUserConfig struct {
+	Profile string `yaml:"profile"`
+}
+
+// AzureUserConfig holds Azure-specific user settings.
+type AzureUserConfig struct {
+	TenantID string `yaml:"tenantId,omitempty"`
+}
+
+// Cluster is a clusters/<name>.yaml (or fragments/<name>.yaml) file describing one cluster.
+type Cluster struct {
 	APIVersion string           `yaml:"apiVersion"`
 	Kind       string           `yaml:"kind"`
 	Metadata   RegistryMetadata `yaml:"metadata"`
 	Provider   string           `yaml:"provider"` // aws, azure, static
-	AWS        *AWSFragment     `yaml:"aws,omitempty"`
-	Azure      *AzureFragment   `yaml:"azure,omitempty"`
+	AWS        *AWSClusterConfig  `yaml:"aws,omitempty"`
+	Azure      *AzureClusterConfig `yaml:"azure,omitempty"`
 	Kubeconfig string           `yaml:"kubeconfig,omitempty"` // for static provider
 }
 
-// AWSFragment holds AWS EKS cluster reference.
-type AWSFragment struct {
+// AWSClusterConfig holds AWS EKS cluster reference.
+type AWSClusterConfig struct {
 	Region  string `yaml:"region"`
 	Cluster string `yaml:"cluster"`
 	Profile string `yaml:"profile,omitempty"`
 }
 
-// AzureFragment holds Azure AKS cluster reference.
-type AzureFragment struct {
+// AzureClusterConfig holds Azure AKS cluster reference.
+type AzureClusterConfig struct {
 	SubscriptionID string `yaml:"subscriptionId"`
 	ResourceGroup  string `yaml:"resourceGroup"`
 	Cluster        string `yaml:"cluster"`
 	TenantID       string `yaml:"tenantId,omitempty"`
 }
+
+// Deprecated aliases for backward compatibility with external code.
+type Fragment = Cluster
+type AWSFragment = AWSClusterConfig
+type AzureFragment = AzureClusterConfig
 
 // KubecmConfig is the local ~/.kubecm/config.yaml state file.
 type KubecmConfig struct {

--- a/pkg/registry/types_test.go
+++ b/pkg/registry/types_test.go
@@ -1,0 +1,150 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestRole_NormalizedContexts_Fragments(t *testing.T) {
+	role := &Role{
+		Fragments: []string{"cluster-a", "cluster-b"},
+	}
+
+	got := role.NormalizedContexts()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 contexts, got %d", len(got))
+	}
+	if got[0].ClusterRef() != "cluster-a" || got[0].User != "" {
+		t.Errorf("context[0] = %+v, want cluster-a", got[0])
+	}
+	if got[1].ClusterRef() != "cluster-b" || got[1].User != "" {
+		t.Errorf("context[1] = %+v, want cluster-b", got[1])
+	}
+}
+
+func TestRole_NormalizedContexts_Contexts(t *testing.T) {
+	role := &Role{
+		Contexts: []RoleContext{
+			{Cluster: "prod", User: "admin", Name: "prod-admin"},
+			{Cluster: "prod", User: "readonly", Name: "prod-ro"},
+		},
+	}
+
+	got := role.NormalizedContexts()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 contexts, got %d", len(got))
+	}
+	if got[0].User != "admin" || got[0].Name != "prod-admin" {
+		t.Errorf("context[0] = %+v", got[0])
+	}
+	if got[1].User != "readonly" || got[1].Name != "prod-ro" {
+		t.Errorf("context[1] = %+v", got[1])
+	}
+}
+
+func TestRole_NormalizedContexts_Both(t *testing.T) {
+	// When both are set, contexts: takes priority
+	role := &Role{
+		Fragments: []string{"old-a", "old-b"},
+		Contexts: []RoleContext{
+			{Cluster: "new-a"},
+		},
+	}
+
+	got := role.NormalizedContexts()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 context (contexts takes priority), got %d", len(got))
+	}
+	if got[0].ClusterRef() != "new-a" {
+		t.Errorf("context[0].ClusterRef() = %q, want %q", got[0].ClusterRef(), "new-a")
+	}
+}
+
+func TestRoleContext_ClusterRef(t *testing.T) {
+	t.Run("cluster field", func(t *testing.T) {
+		rc := RoleContext{Cluster: "prod"}
+		if rc.ClusterRef() != "prod" {
+			t.Errorf("ClusterRef() = %q, want %q", rc.ClusterRef(), "prod")
+		}
+	})
+
+	t.Run("fragment field (deprecated)", func(t *testing.T) {
+		rc := RoleContext{Fragment: "legacy"}
+		if rc.ClusterRef() != "legacy" {
+			t.Errorf("ClusterRef() = %q, want %q", rc.ClusterRef(), "legacy")
+		}
+	})
+
+	t.Run("cluster takes priority over fragment", func(t *testing.T) {
+		rc := RoleContext{Cluster: "new", Fragment: "old"}
+		if rc.ClusterRef() != "new" {
+			t.Errorf("ClusterRef() = %q, want %q", rc.ClusterRef(), "new")
+		}
+	})
+}
+
+func TestValidateRoleContexts_OK(t *testing.T) {
+	role := &Role{
+		Metadata: RegistryMetadata{Name: "devops"},
+		Contexts: []RoleContext{
+			{Cluster: "prod", User: "admin", Name: "prod-admin"},
+			{Cluster: "prod", User: "readonly", Name: "prod-ro"},
+			{Cluster: "staging"},
+		},
+	}
+	if err := ValidateRoleContexts(role); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRoleContexts_DuplicateNames(t *testing.T) {
+	role := &Role{
+		Metadata: RegistryMetadata{Name: "devops"},
+		Contexts: []RoleContext{
+			{Cluster: "prod", User: "admin"},
+			{Cluster: "prod", User: "readonly"},
+		},
+	}
+	err := ValidateRoleContexts(role)
+	if err == nil {
+		t.Error("expected error for duplicate context names")
+	}
+}
+
+func TestValidateRoleContexts_DuplicateWithPrefix(t *testing.T) {
+	role := &Role{
+		Metadata:      RegistryMetadata{Name: "devops"},
+		ContextPrefix: "acme",
+		Contexts: []RoleContext{
+			{Cluster: "prod", User: "admin"},
+			{Cluster: "prod", User: "readonly"},
+		},
+	}
+	err := ValidateRoleContexts(role)
+	if err == nil {
+		t.Error("expected error for duplicate context names with prefix")
+	}
+}
+
+func TestValidateRoleContexts_Empty(t *testing.T) {
+	role := &Role{
+		Metadata: RegistryMetadata{Name: "empty"},
+	}
+	err := ValidateRoleContexts(role)
+	if err == nil {
+		t.Error("expected error for empty role")
+	}
+}
+
+func TestValidateRoleContexts_LegacyFragmentField(t *testing.T) {
+	// Validate works with deprecated fragment: field too
+	role := &Role{
+		Metadata: RegistryMetadata{Name: "legacy"},
+		Contexts: []RoleContext{
+			{Fragment: "prod"},
+			{Fragment: "staging"},
+		},
+	}
+	if err := ValidateRoleContexts(role); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/test/e2e/registry_users_test.go
+++ b/test/e2e/registry_users_test.go
@@ -1,0 +1,460 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupRegistryWithUsers creates a local git repository with a registry structure
+// that includes users/, clusters/ dir, and roles using both fragment: and cluster: fields.
+func setupRegistryWithUsers(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// registry.yaml
+	writeRegistryFile(t, filepath.Join(dir, "registry.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Registry
+metadata:
+  name: e2e-users
+  description: "E2E test registry with users"
+`)
+
+	// fragments/ - legacy directory with static clusters
+	os.MkdirAll(filepath.Join(dir, "fragments"), 0o755)
+
+	writeRegistryFile(t, filepath.Join(dir, "fragments", "legacy-cluster.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Fragment
+metadata:
+  name: legacy-cluster
+provider: static
+kubeconfig: |
+  apiVersion: v1
+  kind: Config
+  clusters:
+    - cluster:
+        server: https://legacy.example.com:6443
+      name: legacy
+  contexts:
+    - context:
+        cluster: legacy
+        user: legacy
+      name: legacy
+  users:
+    - name: legacy
+      user:
+        token: legacy-token
+`)
+
+	writeRegistryFile(t, filepath.Join(dir, "fragments", "shared-cluster.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Fragment
+metadata:
+  name: shared-cluster
+provider: static
+kubeconfig: |
+  apiVersion: v1
+  kind: Config
+  clusters:
+    - cluster:
+        server: https://shared.example.com:6443
+      name: shared
+  contexts:
+    - context:
+        cluster: shared
+        user: shared
+      name: shared
+  users:
+    - name: shared
+      user:
+        token: default-token
+`)
+
+	// clusters/ - new directory
+	os.MkdirAll(filepath.Join(dir, "clusters"), 0o755)
+
+	writeRegistryFile(t, filepath.Join(dir, "clusters", "new-cluster.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Cluster
+metadata:
+  name: new-cluster
+provider: static
+kubeconfig: |
+  apiVersion: v1
+  kind: Config
+  clusters:
+    - cluster:
+        server: https://new.example.com:6443
+      name: new
+  contexts:
+    - context:
+        cluster: new
+        user: new
+      name: new
+  users:
+    - name: new
+      user:
+        token: new-token
+`)
+
+	// users/
+	os.MkdirAll(filepath.Join(dir, "users"), 0o755)
+
+	writeRegistryFile(t, filepath.Join(dir, "users", "admin.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: User
+metadata:
+  name: admin
+provider: static
+`)
+
+	writeRegistryFile(t, filepath.Join(dir, "users", "readonly.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: User
+metadata:
+  name: readonly
+provider: static
+`)
+
+	// roles/
+	os.MkdirAll(filepath.Join(dir, "roles"), 0o755)
+
+	// Legacy role using fragments: list (backward compat)
+	writeRegistryFile(t, filepath.Join(dir, "roles", "legacy.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Role
+metadata:
+  name: legacy
+contextPrefix: "e2e"
+fragments:
+  - legacy-cluster
+  - shared-cluster
+`)
+
+	// Role using contexts: with deprecated fragment: field
+	writeRegistryFile(t, filepath.Join(dir, "roles", "contexts-fragment.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Role
+metadata:
+  name: contexts-fragment
+contextPrefix: "e2e"
+contexts:
+  - fragment: legacy-cluster
+  - fragment: shared-cluster
+`)
+
+	// Role using contexts: with new cluster: field
+	writeRegistryFile(t, filepath.Join(dir, "roles", "contexts-cluster.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Role
+metadata:
+  name: contexts-cluster
+contextPrefix: "e2e"
+contexts:
+  - cluster: legacy-cluster
+  - cluster: new-cluster
+`)
+
+	// Role with user overrides
+	writeRegistryFile(t, filepath.Join(dir, "roles", "with-users.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Role
+metadata:
+  name: with-users
+contextPrefix: "e2e"
+contexts:
+  - cluster: shared-cluster
+    user: admin
+    name: shared-admin
+  - cluster: shared-cluster
+    user: readonly
+    name: shared-ro
+  - cluster: legacy-cluster
+`)
+
+	// Mixed role: cluster: without user + cluster: with user + fragments/ fallback
+	writeRegistryFile(t, filepath.Join(dir, "roles", "mixed.yaml"), `apiVersion: kubecm.io/v1alpha1
+kind: Role
+metadata:
+  name: mixed
+contexts:
+  - cluster: new-cluster
+  - cluster: legacy-cluster
+    user: admin
+    name: legacy-admin
+  - cluster: shared-cluster
+`)
+
+	// Initialize git repo
+	runGitCommand(t, dir, "init", "-b", "main")
+	runGitCommand(t, dir, "add", ".")
+	runGitCommand(t, dir, "commit", "-m", "initial commit")
+
+	return dir
+}
+
+// setupRegistryUsersTest creates a fresh isolated environment for a registry users e2e test.
+func setupRegistryUsersTest(t *testing.T) (repoDir, kubeconfig, kubecmHome string, env map[string]string) {
+	t.Helper()
+
+	repoDir = setupRegistryWithUsers(t)
+	kubeconfig = GetTempKubeconfig(t)
+	kubecmHome = t.TempDir()
+	env = registryEnv(kubeconfig, kubecmHome)
+
+	initialConfig := CreateTestKubeconfig(t, "init.yaml", "initial-cluster", "initial-context")
+	data, err := os.ReadFile(initialConfig)
+	if err != nil {
+		t.Fatalf("reading initial config: %v", err)
+	}
+	if err := os.WriteFile(kubeconfig, data, 0o644); err != nil {
+		t.Fatalf("writing kubeconfig: %v", err)
+	}
+
+	return
+}
+
+// TestRegistryLegacyFragmentsFormat verifies backward compat with the legacy fragments: list.
+func TestRegistryLegacyFragmentsFormat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, kubeconfig, _, env := setupRegistryUsersTest(t)
+
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "legacy")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	output, err := RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "e2e-legacy-cluster") {
+		t.Errorf("expected context 'e2e-legacy-cluster': %s", output)
+	}
+	if !strings.Contains(output, "e2e-shared-cluster") {
+		t.Errorf("expected context 'e2e-shared-cluster': %s", output)
+	}
+
+	// Verify token from legacy fragment
+	data, err := os.ReadFile(kubeconfig)
+	if err != nil {
+		t.Fatalf("reading kubeconfig: %v", err)
+	}
+	if !strings.Contains(string(data), "legacy-token") {
+		t.Errorf("expected 'legacy-token' in kubeconfig")
+	}
+}
+
+// TestRegistryContextsWithFragmentField verifies contexts: with deprecated fragment: field.
+func TestRegistryContextsWithFragmentField(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, _, _, env := setupRegistryUsersTest(t)
+
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "contexts-fragment")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	output, err := RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "e2e-legacy-cluster") {
+		t.Errorf("expected context 'e2e-legacy-cluster': %s", output)
+	}
+	if !strings.Contains(output, "e2e-shared-cluster") {
+		t.Errorf("expected context 'e2e-shared-cluster': %s", output)
+	}
+}
+
+// TestRegistryContextsWithClusterField verifies contexts: with new cluster: field,
+// including loading from the new clusters/ directory.
+func TestRegistryContextsWithClusterField(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, kubeconfig, _, env := setupRegistryUsersTest(t)
+
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "contexts-cluster")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	output, err := RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+	// legacy-cluster loaded from fragments/ (fallback)
+	if !strings.Contains(output, "e2e-legacy-cluster") {
+		t.Errorf("expected context 'e2e-legacy-cluster' (from fragments/ fallback): %s", output)
+	}
+	// new-cluster loaded from clusters/ (new dir)
+	if !strings.Contains(output, "e2e-new-cluster") {
+		t.Errorf("expected context 'e2e-new-cluster' (from clusters/ dir): %s", output)
+	}
+
+	data, err := os.ReadFile(kubeconfig)
+	if err != nil {
+		t.Fatalf("reading kubeconfig: %v", err)
+	}
+	if !strings.Contains(string(data), "new-token") {
+		t.Errorf("expected 'new-token' from clusters/ directory in kubeconfig")
+	}
+}
+
+// TestRegistryWithUserOverrides verifies that user overrides work,
+// including same cluster with different users producing different context names.
+func TestRegistryWithUserOverrides(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, _, _, env := setupRegistryUsersTest(t)
+
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "with-users")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	output, err := RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+
+	// Same cluster with two different users -> two distinct context names
+	if !strings.Contains(output, "e2e-shared-admin") {
+		t.Errorf("expected context 'e2e-shared-admin': %s", output)
+	}
+	if !strings.Contains(output, "e2e-shared-ro") {
+		t.Errorf("expected context 'e2e-shared-ro': %s", output)
+	}
+	// Cluster without user override
+	if !strings.Contains(output, "e2e-legacy-cluster") {
+		t.Errorf("expected context 'e2e-legacy-cluster': %s", output)
+	}
+}
+
+// TestRegistryMixedMode verifies a role mixing clusters/ dir, fragments/ fallback,
+// and user overrides in a single sync.
+func TestRegistryMixedMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, _, _, env := setupRegistryUsersTest(t)
+
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "mixed")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	output, err := RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+
+	// new-cluster from clusters/ dir, no user
+	if !strings.Contains(output, "new-cluster") {
+		t.Errorf("expected context 'new-cluster': %s", output)
+	}
+	// legacy-cluster from fragments/ fallback, with user, custom name
+	if !strings.Contains(output, "legacy-admin") {
+		t.Errorf("expected context 'legacy-admin': %s", output)
+	}
+	// shared-cluster from fragments/, no user
+	if !strings.Contains(output, "shared-cluster") {
+		t.Errorf("expected context 'shared-cluster': %s", output)
+	}
+}
+
+// TestRegistryUsersSwitchRole verifies switching from a legacy role to a user-based role
+// correctly removes old contexts and adds new ones.
+func TestRegistryUsersSwitchRole(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, _, _, env := setupRegistryUsersTest(t)
+
+	// Start with legacy role
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "legacy")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	output, err := RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "e2e-legacy-cluster") {
+		t.Errorf("expected e2e-legacy-cluster with legacy role: %s", output)
+	}
+	if !strings.Contains(output, "e2e-shared-cluster") {
+		t.Errorf("expected e2e-shared-cluster with legacy role: %s", output)
+	}
+
+	// Switch to with-users role
+	_, err = RunKubecmWithEnv(t, env, "registry", "update", "acme", "--role", "with-users")
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	_, err = RunKubecmWithEnv(t, env, "registry", "sync", "acme")
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	output, err = RunKubecmWithEnv(t, env, "list")
+	if err != nil {
+		t.Fatalf("list failed: %v\nOutput: %s", err, output)
+	}
+
+	// Old shared-cluster context should be removed (replaced by named ones)
+	if strings.Contains(output, "e2e-shared-cluster") {
+		t.Errorf("e2e-shared-cluster should have been removed after role switch: %s", output)
+	}
+	// New named contexts should exist
+	if !strings.Contains(output, "e2e-shared-admin") {
+		t.Errorf("expected e2e-shared-admin after role switch: %s", output)
+	}
+	if !strings.Contains(output, "e2e-shared-ro") {
+		t.Errorf("expected e2e-shared-ro after role switch: %s", output)
+	}
+	// legacy-cluster is in both roles, should still exist
+	if !strings.Contains(output, "e2e-legacy-cluster") {
+		t.Errorf("expected e2e-legacy-cluster preserved after role switch: %s", output)
+	}
+}
+
+// TestRegistrySyncDryRunWithUsers verifies dry-run with user overrides.
+func TestRegistrySyncDryRunWithUsers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping e2e test in short mode")
+	}
+
+	repoDir, _, _, env := setupRegistryUsersTest(t)
+
+	_, err := RunKubecmWithEnv(t, env,
+		"registry", "add", "--name", "acme", "--url", repoDir, "--role", "with-users")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	// Dry-run should show what would change
+	output, err := RunKubecmWithEnv(t, env, "registry", "sync", "acme", "--dry-run")
+	if err != nil {
+		t.Fatalf("sync --dry-run failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "dry-run") {
+		t.Errorf("expected dry-run notice: %s", output)
+	}
+	if !strings.Contains(output, "e2e-shared-admin") {
+		t.Errorf("expected e2e-shared-admin in dry-run output: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary

First of all, thanks a lot for merging the registry feature in #1171 — I'm really happy it made it in!

Since yesterday I've been showing it to colleagues and people around me, and they immediately asked for better handling of common real-world scenarios: the same user (AWS profile) across multiple clusters, or multiple users (admin + readonly) for the same cluster. So here's a v2 proposal that adds exactly that.

Even though 0.35 is still fresh, I took the opportunity to rename `Fragment` to `Cluster` throughout the codebase since the 1:1 mapping (one fragment = one cluster) made the original naming confusing. The code is fully backward compatible (`fragments/` dir, `kind: Fragment`, `fragment:` field in roles all still work), but the documentation now uses the cleaner naming so new users start with the right terminology from day one.

### What's new

**User type** (`users/<name>.yaml`): defines reusable credentials (AWS profile, Azure tenantId) independently from cluster topology.

```yaml
apiVersion: kubecm.io/v1alpha1
kind: User
metadata:
  name: admin
provider: aws
aws:
  profile: "my-account/AWSAdministratorAccess"
```

**Role `contexts:` format**: binds clusters to users, allowing the same cluster with different identities:

```yaml
contexts:
  - cluster: eks-prod
    user: admin
    name: eks-prod-admin
  - cluster: eks-prod
    user: readonly
    name: eks-prod-ro
  - cluster: eks-staging     # no user = credentials from cluster definition
```

**Rename Fragment -> Cluster**: `Cluster` type, `clusters/` directory, `LoadCluster`, `ResolveCluster`, etc. Type aliases preserve backward compat.

### Changes

- `pkg/registry/types.go`: `User`, `AWSUserConfig`, `AzureUserConfig`, `RoleContext` with `cluster:`/`user:`/`name:`, `ClusterRef()`, type aliases
- `pkg/registry/config.go`: `LoadCluster` (clusters/ + fragments/ fallback), `LoadUser`
- `pkg/registry/resolve.go`: `ResolveClusterWithUser`, `cloneCluster`
- `pkg/registry/template.go`: `ResolveClusterTemplates`, `ResolveUserTemplates`
- `pkg/registry/sync.go`: `ValidateRoleContexts`, refactored `Sync` loop using `ClusterRef()`
- `docs/en-us/registry.md`: rewritten for Cluster/User model
- `test/e2e/registry_users_test.go`: 7 new e2e tests

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/registry/... -v` — 43 tests pass (existing + new)
- [x] `go test ./test/e2e/ -run TestRegistry -v` — 17 e2e tests pass (existing + 7 new)
- [x] Live test with real AWS EKS registry (10 clusters, both legacy `fragments:` and new `contexts:` + users)