### PR TITLE
docs: fix Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Be sure to follow our [Community Guidelines](https://kubecm.cloud/en-us/contribu
 
 ## 📈 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sunny0826/kubecm&type=Date)](https://star-history.com/#sunny0826/kubecm)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sunny0826/kubecm&type=Date)](https://star-history.dera.page/#sunny0826/kubecm)
 
 ## ✨ Contributors
 

--- a/docs/en-us/contribute.md
+++ b/docs/en-us/contribute.md
@@ -45,7 +45,7 @@ By contributing, you agree that your contributions will be licensed under its [L
 
 ## Star History 📈
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sunny0826/kubecm&type=Date)](https://star-history.com/#sunny0826/kubecm)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sunny0826/kubecm&type=Date)](https://star-history.dera.page/#sunny0826/kubecm)
 
 ## Contributors ✨
 


### PR DESCRIPTION
The Star History charts in the README and contribution guide are broken because the previous service can no longer render them under GitHub stargazer API restrictions.

This change points the charts to an alternative provider that uses a different, token-free data source, so the charts render correctly again. The fix applies to both README.md and docs/en-us/contribute.md.